### PR TITLE
Fix auto-linking for Twitter

### DIFF
--- a/about.md
+++ b/about.md
@@ -27,7 +27,7 @@ free Internet!
 
 ## Contact me
 
-If you want to reach me, @zimbatm on [Twitter](https://twitter.com/zimbatm),
+If you want to reach me, [@zimbatm on Twitter](https://twitter.com/zimbatm),
 [GitHub](https://github.com/zimbatm/), send an email to, you guessed
 it, [zimbatm@zimbatm.com](mailto:zimbatm@zimbatm.com) .
 


### PR DESCRIPTION
You seem to have used some auto-linking to link @ mentions to GitHub.

This is, however, very confusing in this case:
![image](https://user-images.githubusercontent.com/11966684/58115554-a01ff480-7bfa-11e9-8f09-0b7fb0dddea1.png) (first link goes to GitHub)

I clicked on that handle and thought: "Ough, were not I am supposed to be on Twitter?" :thinking: 

I hope this change fixes it. :smile: 